### PR TITLE
Review updates

### DIFF
--- a/src/BitzArt.XDoc/Utility/XmlParser.cs
+++ b/src/BitzArt.XDoc/Utility/XmlParser.cs
@@ -230,7 +230,7 @@ internal class XmlParser
         // Get the generic arguments and format them recursively
         var genericArgs = string.Join(",", type.GetGenericArguments().Select(GetTypeFriendlyName));
 
-        return $"{typeName}{{{genericArgs}}}";
+        return typeName + '{' + genericArgs + '}';
     }
 
     private static bool IsGeneric(string? typeName) => !string.IsNullOrWhiteSpace(typeName) && typeName.Contains('`');

--- a/src/BitzArt.XDoc/Utility/XmlParser.cs
+++ b/src/BitzArt.XDoc/Utility/XmlParser.cs
@@ -128,8 +128,8 @@ internal class XmlParser
     private static ConstructorInfo? GetConstructor(Type ownerType, IReadOnlyCollection<string> parameters, bool isStatic = false)
     {
         var bindingFlags = isStatic
-            ? BindingFlags.Static | BindingFlags.Public
-            : BindingFlags.Instance | BindingFlags.Public;
+            ? BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic
+            : BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
         var constructors = ownerType.GetConstructors(bindingFlags);
 


### PR DESCRIPTION
This pull request refactors the `XmlMemberNameResolver` and `XmlParser` classes in the `BitzArt.XDoc` library to streamline the code by removing redundant methods, improving readability, and leveraging modern C# features. The changes focus on simplifying logic, reducing duplication, and enhancing maintainability.

### Refactoring and Simplification in `XmlMemberNameResolver`:

* Removed redundant private helper methods (`IsMethod`, `IsGeneric`, `HasMethodParameters`, `HasGenericTypeParameters`, etc.) and inlined their logic directly into the main methods, improving code clarity and reducing method overhead. [[1]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L26-R27) [[2]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L43-R57) [[3]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L78-L133) [[4]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L215-L260)
* Replaced `ImmutableArray<string>.Empty` with the more concise `[]` for representing empty collections in `ResolveMethodParameters`. [[1]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L150-R110) [[2]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L168-R123)
* Simplified parameter parsing in `ParseParameterList` by directly handling separators and nesting depth without additional helper methods. [[1]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L190-R143) [[2]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L215-L260)

### Refactoring and Modernization in `XmlParser`:

* Combined null checks with initialization using the null-coalescing operator (`??`) for cleaner and more concise code in `Parse` and `ParseMemberNode`. [[1]](diffhunk://#diff-8be820da7f3d260d4df9f72710e9409d1fed69c0f8713202e82952f3f0b8266dL39-R40) [[2]](diffhunk://#diff-8be820da7f3d260d4df9f72710e9409d1fed69c0f8713202e82952f3f0b8266dL187-R190)
* Refactored `GetMethodOrConstructor` to use a `switch` expression for determining constructors or methods, improving readability.
* Enhanced `GetConstructor` to include an optional `isStatic` parameter, allowing differentiation between static and instance constructors.

These changes collectively improve the maintainability and readability of the code while reducing redundancy.