### PR TITLE
Review updates

### DIFF
--- a/src/BitzArt.XDoc/Utility/XmlMemberNameResolver.cs
+++ b/src/BitzArt.XDoc/Utility/XmlMemberNameResolver.cs
@@ -77,14 +77,14 @@ internal static partial class XmlMemberNameResolver
     /// <returns>
     /// A read-only collection of parameter type names as strings. Returns an empty collection if no parameters are found.
     /// </returns>
-    public static IReadOnlyCollection<string>? ResolveMethodParameters(string xmlDocumentationMemberName)
+    public static IReadOnlyCollection<string> ResolveMethodParameters(string xmlDocumentationMemberName)
     {
         var parameterListStartIndex = xmlDocumentationMemberName.IndexOf('(');
 
         if (parameterListStartIndex == -1)
         {
             // No parameter list found
-            return null;
+            return [];
         }
 
         var parameterListEndIndex = xmlDocumentationMemberName.LastIndexOf(')');
@@ -102,7 +102,7 @@ internal static partial class XmlMemberNameResolver
         if (string.IsNullOrWhiteSpace(parametersString))
         {
             // No parameters found
-            return null;
+            return [];
         }
 
         // Handle nested generic parameters while tracking nesting depth

--- a/src/BitzArt.XDoc/Utility/XmlMemberNameResolver.cs
+++ b/src/BitzArt.XDoc/Utility/XmlMemberNameResolver.cs
@@ -7,8 +7,10 @@ namespace BitzArt.XDoc;
 /// such as extracting type names, member names, and method parameter types. 
 /// Handles special cases including generic types and nested generic parameters.
 /// </summary>
-internal static class XmlMemberNameResolver
+internal static partial class XmlMemberNameResolver
 {
+    public record TypeAndMemberName(string TypeName, string MemberName);
+
     /// <summary>
     /// Resolves a qualified member name into its associated type and member name.
     /// Handles special cases like generic types and methods with parameters.
@@ -20,7 +22,7 @@ internal static class XmlMemberNameResolver
     /// <exception cref="InvalidOperationException">
     /// Thrown when the name doesn't contain a type/member separator or when the type cannot be found
     /// </exception>
-    public static (string typeName, string memberName) ResolveTypeAndMemberName(string xmlDocumentationMemberName)
+    public static TypeAndMemberName ResolveTypeAndMemberName(string xmlDocumentationMemberName)
     {
         // A member name containing an opening parenthesis indicates a method.
         if (xmlDocumentationMemberName.Contains('('))
@@ -31,7 +33,11 @@ internal static class XmlMemberNameResolver
             xmlDocumentationMemberName = xmlDocumentationMemberName[..xmlDocumentationMemberName.IndexOf('(')];
         }
 
-        EnsureContainsTypeSeparator(xmlDocumentationMemberName);
+        if (!xmlDocumentationMemberName.Contains('.'))
+        {
+            throw new InvalidOperationException(
+                $"XML documentation member name '{xmlDocumentationMemberName}' does not contain a type separator.");
+        }
 
         // Find the position of the last dot in the member name, which separates
         // the type name from the member name (e.g., "Namespace.TypeName.MemberName" -> position of last dot)
@@ -40,12 +46,10 @@ internal static class XmlMemberNameResolver
         var typeName = xmlDocumentationMemberName[..indexOfLastDot];
         var memberName = xmlDocumentationMemberName[(indexOfLastDot + 1)..];
 
-        // If the member name contains a backtick (`),
-        // it indicates a generic type or method.
+        // Backtick (`) => generic type or method.
         if (xmlDocumentationMemberName.Contains('`'))
         {
-            // If member name contains an opening parenthesis,
-            // it indicates a method with parameters.
+            // Opening parenthesis indicates a method with parameters.
             if (memberName.Contains('('))
             {
                 memberName = memberName[..memberName.IndexOf('(')];
@@ -60,25 +64,7 @@ internal static class XmlMemberNameResolver
             }
         }
 
-        return (typeName, memberName);
-    }
-
-    /// <summary>
-    /// Ensures the XML documentation member name contains a type separator (dot).
-    /// </summary>
-    /// <param name="xmlDocumentationMemberName">The XML documentation member name to check.</param>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when the XML documentation member name doesn't contain a type separator.
-    /// </exception>
-    private static void EnsureContainsTypeSeparator(string xmlDocumentationMemberName)
-    {
-        var indexOfLastDot = xmlDocumentationMemberName.LastIndexOf('.');
-
-        if (indexOfLastDot == -1)
-        {
-            throw new InvalidOperationException(
-                $"XML documentation member name '{xmlDocumentationMemberName}' does not contain a type separator.");
-        }
+        return new(typeName, memberName);
     }
 
     /// <summary>
@@ -91,22 +77,22 @@ internal static class XmlMemberNameResolver
     /// <returns>
     /// A read-only collection of parameter type names as strings. Returns an empty collection if no parameters are found.
     /// </returns>
-    public static IReadOnlyCollection<string> ResolveMethodParameters(string xmlDocumentationMemberName)
+    public static IReadOnlyCollection<string>? ResolveMethodParameters(string xmlDocumentationMemberName)
     {
         var parameterListStartIndex = xmlDocumentationMemberName.IndexOf('(');
 
         if (parameterListStartIndex == -1)
         {
-            // No parameters found
-            return [];
+            // No parameter list found
+            return null;
         }
 
         var parameterListEndIndex = xmlDocumentationMemberName.LastIndexOf(')');
 
         if (parameterListEndIndex <= parameterListStartIndex)
         {
-            // No valid parameter list found
-            return [];
+            throw new InvalidOperationException(
+                $"XML documentation member '{xmlDocumentationMemberName}' parameter list is invalid.");
         }
 
         var parametersString = xmlDocumentationMemberName.Substring(
@@ -116,7 +102,7 @@ internal static class XmlMemberNameResolver
         if (string.IsNullOrWhiteSpace(parametersString))
         {
             // No parameters found
-            return [];
+            return null;
         }
 
         // Handle nested generic parameters while tracking nesting depth
@@ -129,53 +115,54 @@ internal static class XmlMemberNameResolver
     /// </summary>
     /// <param name="parametersString">String containing comma-separated parameter type names.</param>
     /// <returns>A collection of parsed and cleaned parameter type names.</returns>
-    private static IReadOnlyCollection<string> ParseParameterList(string parametersString)
+    private static List<string> ParseParameterList(string parametersString)
     {
-        var parameters = new List<string>();
+        var result = new List<string>();
         var currentParam = string.Empty;
-        var angleBracketDepth = 0;
+        var nestingDepth = 0;
 
         foreach (var c in parametersString)
         {
-            // If the character is a comma and we are not inside any nested generic type,
-            // we consider it a separator for parameters.
-            if (c is ',' && angleBracketDepth == 0)
+            switch (c)
             {
-                parameters.Add(RemoveGenericMarkers(currentParam.Trim()));
-                currentParam = string.Empty;
+                case '<' or '{':
+                    nestingDepth++;
+                    break;
 
-                continue;
+                case '>' or '}':
+                    nestingDepth--;
+                    break;
+
+                case ',' when nestingDepth == 0:
+                    {
+                        currentParam = currentParam.Trim();
+                        currentParam = RemoveGenericMarkers(currentParam);
+
+                        result.Add(RemoveGenericMarkers(currentParam));
+
+                        currentParam = string.Empty;
+
+                        continue;
+                    }
             }
-
-            // Track bracket depth to handle nested generics
-            angleBracketDepth = TrackBracketDepth(c, angleBracketDepth);
 
             currentParam += c;
         }
 
-        // Add the last parameter
         if (!string.IsNullOrWhiteSpace(currentParam))
         {
-            parameters.Add(RemoveGenericMarkers(currentParam.Trim()));
+            result.Add(RemoveGenericMarkers(currentParam.Trim()));
         }
 
-        return parameters;
-    }
-
-    private static int TrackBracketDepth(char c, int currentBracketDepth)
-    {
-        return c switch
-        {
-            '<' or '{' => ++currentBracketDepth, // Opening brackets increase the depth
-            '>' or '}' => --currentBracketDepth, // Closing brackets decrease the depth
-            _ => currentBracketDepth // No change in depth for other characters
-        };
+        return result;
     }
 
     /// <summary>
-    /// Remove generic markers like `0, `1, etc. and any standalone backticks
+    /// Matches generic markers like `0, `1, etc. and any standalone backticks
     /// </summary>
-    /// <param name="value"></param>
     /// <returns></returns>
-    private static string RemoveGenericMarkers(string value) => Regex.Replace(value, @"`\d+", "").Replace("`", "");
+    [GeneratedRegex(@"\`\d+|\`")]
+    private static partial Regex GetGenericMarkerRegex();
+
+    internal static string RemoveGenericMarkers(string value) => GetGenericMarkerRegex().Replace(value, string.Empty);
 }

--- a/src/BitzArt.XDoc/Utility/XmlParser.cs
+++ b/src/BitzArt.XDoc/Utility/XmlParser.cs
@@ -101,7 +101,7 @@ internal class XmlParser
             (type, memberName, parameters) => GetMethodOrConstructor(type, memberName, parameters),
             member => new MethodDocumentation(_source, member, node));
 
-    private static MethodBase? GetMethodOrConstructor(Type type, string name, IReadOnlyCollection<string>? parameters)
+    private static MethodBase? GetMethodOrConstructor(Type type, string name, IReadOnlyCollection<string> parameters)
         => name switch
         {
             "#ctor" => GetConstructor(type, parameters),
@@ -109,7 +109,7 @@ internal class XmlParser
             _ => GetMethod(type, name, parameters)
         };
 
-    private static MethodInfo? GetMethod(Type ownerType, string name, IReadOnlyCollection<string>? parameters)
+    private static MethodInfo? GetMethod(Type ownerType, string name, IReadOnlyCollection<string> parameters)
     {
         var methods = ownerType.GetMethods();
 
@@ -125,7 +125,7 @@ internal class XmlParser
         return method;
     }
 
-    private static ConstructorInfo? GetConstructor(Type ownerType, IReadOnlyCollection<string>? parameters, bool isStatic = false)
+    private static ConstructorInfo? GetConstructor(Type ownerType, IReadOnlyCollection<string> parameters, bool isStatic = false)
     {
         var bindingFlags = isStatic
             ? BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic
@@ -153,11 +153,11 @@ internal class XmlParser
     /// <returns>True if the parameter signatures match; otherwise, false.</returns>
     private static bool HasMatchingParameterTypes(
         ParameterInfo[] actualParameters,
-        IReadOnlyCollection<string>? expectedParameters)
+        IReadOnlyCollection<string> expectedParameters)
     {
-        if (expectedParameters is null)
+        if (actualParameters.Length == 0 && expectedParameters.Count == 0)
         {
-            return actualParameters.Length == 0;
+            return true;
         }
 
         if (actualParameters.Length != expectedParameters.Count)
@@ -174,7 +174,7 @@ internal class XmlParser
 
     private TDocumentation ParseMemberNode<TMember, TDocumentation>(
         string name,
-        Func<Type, string, IReadOnlyCollection<string>?, TMember?> getMember,
+        Func<Type, string, IReadOnlyCollection<string>, TMember?> getMember,
         Func<TMember, TDocumentation> getDocumentation)
         where TMember : MemberInfo
         where TDocumentation : MemberDocumentation<TMember>

--- a/src/BitzArt.XDoc/Utility/XmlParser.cs
+++ b/src/BitzArt.XDoc/Utility/XmlParser.cs
@@ -101,7 +101,7 @@ internal class XmlParser
             (type, memberName, parameters) => GetMethodOrConstructor(type, memberName, parameters),
             member => new MethodDocumentation(_source, member, node));
 
-    private static MethodBase? GetMethodOrConstructor(Type type, string name, IReadOnlyCollection<string> parameters)
+    private static MethodBase? GetMethodOrConstructor(Type type, string name, IReadOnlyCollection<string>? parameters)
         => name switch
         {
             "#ctor" => GetConstructor(type, parameters),
@@ -109,7 +109,7 @@ internal class XmlParser
             _ => GetMethod(type, name, parameters)
         };
 
-    private static MethodInfo? GetMethod(Type ownerType, string name, IReadOnlyCollection<string> parameters)
+    private static MethodInfo? GetMethod(Type ownerType, string name, IReadOnlyCollection<string>? parameters)
     {
         var methods = ownerType.GetMethods();
 
@@ -125,7 +125,7 @@ internal class XmlParser
         return method;
     }
 
-    private static ConstructorInfo? GetConstructor(Type ownerType, IReadOnlyCollection<string> parameters, bool isStatic = false)
+    private static ConstructorInfo? GetConstructor(Type ownerType, IReadOnlyCollection<string>? parameters, bool isStatic = false)
     {
         var bindingFlags = isStatic
             ? BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic
@@ -153,11 +153,11 @@ internal class XmlParser
     /// <returns>True if the parameter signatures match; otherwise, false.</returns>
     private static bool HasMatchingParameterTypes(
         ParameterInfo[] actualParameters,
-        IReadOnlyCollection<string> expectedParameters)
+        IReadOnlyCollection<string>? expectedParameters)
     {
-        if (actualParameters.Length == 0 && expectedParameters.Count == 0)
+        if (expectedParameters is null)
         {
-            return true;
+            return actualParameters.Length == 0;
         }
 
         if (actualParameters.Length != expectedParameters.Count)
@@ -174,7 +174,7 @@ internal class XmlParser
 
     private TDocumentation ParseMemberNode<TMember, TDocumentation>(
         string name,
-        Func<Type, string, IReadOnlyCollection<string>, TMember?> getMember,
+        Func<Type, string, IReadOnlyCollection<string>?, TMember?> getMember,
         Func<TMember, TDocumentation> getDocumentation)
         where TMember : MemberInfo
         where TDocumentation : MemberDocumentation<TMember>

--- a/tests/BitzArt.XDoc.Tests.E2E/BitzArt.XDoc.Tests.E2E.csproj
+++ b/tests/BitzArt.XDoc.Tests.E2E/BitzArt.XDoc.Tests.E2E.csproj
@@ -6,6 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>1591</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/BitzArt.XDoc.Tests/BitzArt.XDoc.Tests.csproj
+++ b/tests/BitzArt.XDoc.Tests/BitzArt.XDoc.Tests.csproj
@@ -23,7 +23,6 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="XDoc.IncludeXmlDocumentation" Version="0.0.3-alpha" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/BitzArt.XDoc.Tests/Tests/InheritanceResolverTests.cs
+++ b/tests/BitzArt.XDoc.Tests/Tests/InheritanceResolverTests.cs
@@ -1,4 +1,4 @@
-namespace BitzArt.XDoc.PlainText.Tests;
+namespace BitzArt.XDoc.Tests;
 
 class MyClassWithoutInheritance
 {

--- a/tests/BitzArt.XDoc.Tests/Tests/MemberDocumentationTests.cs
+++ b/tests/BitzArt.XDoc.Tests/Tests/MemberDocumentationTests.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 using System.Xml;
 
-namespace BitzArt.XDoc.PlainText.Tests;
+namespace BitzArt.XDoc.Tests;
 
 abstract class BaseClass
 {

--- a/tests/BitzArt.XDoc.Tests/Tests/XmlMemberNameResolverTests.cs
+++ b/tests/BitzArt.XDoc.Tests/Tests/XmlMemberNameResolverTests.cs
@@ -2,6 +2,22 @@ namespace BitzArt.XDoc.Tests;
 
 public class XmlMemberNameResolverTests
 {
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("`", "")]
+    [InlineData("NameSpace.MyClass`", "NameSpace.MyClass")]
+    [InlineData("NameSpace.MyClass`1", "NameSpace.MyClass")]
+    [InlineData("NameSpace.MyClass`.MyMethod", "NameSpace.MyClass.MyMethod")]
+    [InlineData("NameSpace.MyClass`1.MyMethod", "NameSpace.MyClass.MyMethod")]
+    public void RemoveGenericMarkers_OnValidInput_ShouldReplace(string input, string expected)
+    {
+        // Act
+        var result = XmlMemberNameResolver.RemoveGenericMarkers(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
     [Fact]
     public void ResolveTypeAndMemberName_GenericMethod_ShouldResolve()
     {

--- a/tests/Render/BitzArt.XDoc.PlainText.Tests.E2E/BitzArt.XDoc.PlainText.Tests.E2E.csproj
+++ b/tests/Render/BitzArt.XDoc.PlainText.Tests.E2E/BitzArt.XDoc.PlainText.Tests.E2E.csproj
@@ -6,6 +6,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>1591</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/Render/BitzArt.XDoc.PlainText.Tests/BitzArt.XDoc.PlainText.Tests.csproj
+++ b/tests/Render/BitzArt.XDoc.PlainText.Tests/BitzArt.XDoc.PlainText.Tests.csproj
@@ -8,6 +8,7 @@
         <IsTestProject>true</IsTestProject>
         <TargetFramework>net9.0</TargetFramework>
 		<RootNamespace>BitzArt.XDoc.PlainText.Tests</RootNamespace>
+        <NoWarn>8618,8625</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/Render/BitzArt.XDoc.PlainText.Tests/PlainTextRendererTests.cs
+++ b/tests/Render/BitzArt.XDoc.PlainText.Tests/PlainTextRendererTests.cs
@@ -58,7 +58,7 @@ public class PlainTextRendererTests
         var xmlDocument = new XmlDocument();
         xmlDocument.LoadXml(xml);
 
-        var node = xmlDocument.SelectSingleNode("//inheritdoc");
+        var node = xmlDocument.SelectSingleNode("//inheritdoc")!;
 
         var memberDocumentation = new TestDocumentationElement(node);
 


### PR DESCRIPTION
This pull request refactors the `XmlMemberNameResolver` utility and updates related tests and functionality across the codebase. Key changes include introducing a new `TypeAndMemberName` record type, simplifying generic marker handling, improving parameter resolution logic, and enhancing test coverage. Additionally, some files have been renamed for better organization.

### Refactoring of `XmlMemberNameResolver`:

* Changed `XmlMemberNameResolver` to a partial class and introduced a `TypeAndMemberName` record type for better readability and type safety in resolving type and member names. [[1]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L10-R13) [[2]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L23-R25)
* Simplified the logic for ensuring type separators and removed redundant helper methods. [[1]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L34-R40) [[2]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L63-R67)
* Improved parameter resolution logic by returning `null` for invalid or missing parameters and throwing exceptions for malformed parameter lists. [[1]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L94-R95) [[2]](diffhunk://#diff-013c008bdacad3929190b2262d2cc9e634084eeffd73a17a7f8ffc3f0cd9eed6L119-R105)
* Updated the `ParseParameterList` method to use a more intuitive nesting depth tracking approach and removed unnecessary code.

### Updates to `XmlParser`:

* Adjusted several methods to accept nullable parameter collections (`IReadOnlyCollection<string>?`) to align with the updated parameter resolution logic. [[1]](diffhunk://#diff-8be820da7f3d260d4df9f72710e9409d1fed69c0f8713202e82952f3f0b8266dL104-R112) [[2]](diffhunk://#diff-8be820da7f3d260d4df9f72710e9409d1fed69c0f8713202e82952f3f0b8266dL128-R128) [[3]](diffhunk://#diff-8be820da7f3d260d4df9f72710e9409d1fed69c0f8713202e82952f3f0b8266dL156-R160) [[4]](diffhunk://#diff-8be820da7f3d260d4df9f72710e9409d1fed69c0f8713202e82952f3f0b8266dL177-R177)

### Test enhancements:

* Added new unit tests for `XmlMemberNameResolver.RemoveGenericMarkers` to ensure proper handling of generic markers.
* Renamed test files (`InheritanceResolverTests.cs` and `MemberDocumentationTests.cs`) for better organization and updated namespaces accordingly. [[1]](diffhunk://#diff-126a6b482d55cf0541a3d00c6c2b5a052ca76b56559b03314a553897531846d7L1-R1) [[2]](diffhunk://#diff-87360845ed6b0804da242cfb647c1c6aa48dd938019eadcc4fafd36fe8fbb3c3L4-R4)

### Dependency cleanup:

* Removed the `XDoc.IncludeXmlDocumentation` package reference from the test project as it is no longer needed.